### PR TITLE
Add support for Auth using default AWS SDK credentials provider

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -55,6 +55,12 @@ func NewAuth(accessKey, secretKey, token string) *AuthCredentials {
 	}
 }
 
+// NewEmptyAuth creates a *AuthCredentials struct that adheres to the Auth interface
+// but contains no credentials and does not Sign requests
+func NewEmptyAuth() *AuthCredentials {
+	return &AuthCredentials{}
+}
+
 // NewAuthFromEnv retrieves auth credentials from environment vars
 func NewAuthFromEnv() (*AuthCredentials, error) {
 	accessKey := os.Getenv(AccessEnvKey)

--- a/auth_test.go
+++ b/auth_test.go
@@ -36,23 +36,6 @@ func TestGetToken(t *testing.T) {
 	}
 }
 
-func TestNewEmptyAuth(t *testing.T) {
-	auth := NewEmptyAuth()
-
-	if auth.GetAccessKey() != "" {
-		t.Error("expected empty auth#accessKey")
-	}
-	if auth.GetSecretKey() != "" {
-		t.Error("expected empty auth#secretKey")
-	}
-	if auth.GetToken() != "" {
-		t.Error("expected empty auth#token")
-	}
-	if auth.HasExpiration() != false {
-		t.Error("expected no expiration")
-	}
-}
-
 func TestNewAuthFromEnv(t *testing.T) {
 	os.Setenv(AccessEnvKey, "asdf")
 	os.Setenv(SecretEnvKey, "asdf2")

--- a/auth_test.go
+++ b/auth_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 )
 
+func swallowErr(s string, e error) string {
+	return s
+}
+
 func TestAuthInterfaceIsImplemented(t *testing.T) {
 	var auth Auth = &AuthCredentials{}
 	if auth == nil {
@@ -15,7 +19,7 @@ func TestAuthInterfaceIsImplemented(t *testing.T) {
 func TestGetSecretKey(t *testing.T) {
 	auth := NewAuth("BAD_ACCESS_KEY", "BAD_SECRET_KEY", "BAD_SECURITY_TOKEN")
 
-	if auth.GetAccessKey() != "BAD_ACCESS_KEY" {
+	if swallowErr(auth.GetAccessKey()) != "BAD_ACCESS_KEY" {
 		t.Error("incorrect value for auth#accessKey")
 	}
 }
@@ -23,7 +27,7 @@ func TestGetSecretKey(t *testing.T) {
 func TestGetAccessKey(t *testing.T) {
 	auth := NewAuth("BAD_ACCESS_KEY", "BAD_SECRET_KEY", "BAD_SECURITY_TOKEN")
 
-	if auth.GetSecretKey() != "BAD_SECRET_KEY" {
+	if swallowErr(auth.GetSecretKey()) != "BAD_SECRET_KEY" {
 		t.Error("incorrect value for auth#secretKey")
 	}
 }
@@ -31,7 +35,7 @@ func TestGetAccessKey(t *testing.T) {
 func TestGetToken(t *testing.T) {
 	auth := NewAuth("BAD_ACCESS_KEY", "BAD_SECRET_KEY", "BAD_SECURITY_TOKEN")
 
-	if auth.GetToken() != "BAD_SECURITY_TOKEN" {
+	if swallowErr(auth.GetToken()) != "BAD_SECURITY_TOKEN" {
 		t.Error("incorrect value for auth#token")
 	}
 }
@@ -47,15 +51,15 @@ func TestNewAuthFromEnv(t *testing.T) {
 
 	auth, _ := NewAuthFromEnv()
 
-	if auth.GetAccessKey() != "asdf" {
+	if swallowErr(auth.GetAccessKey()) != "asdf" {
 		t.Error("Expected AccessKey to be inferred as \"asdf\"")
 	}
 
-	if auth.GetSecretKey() != "asdf2" {
+	if swallowErr(auth.GetSecretKey()) != "asdf2" {
 		t.Error("Expected SecretKey to be inferred as \"asdf2\"")
 	}
 
-	if auth.GetToken() != "dummy_token" {
+	if swallowErr(auth.GetToken()) != "dummy_token" {
 		t.Error("Expected SecurityToken to be inferred as \"dummy_token\"")
 	}
 }
@@ -70,15 +74,15 @@ func TestNewAuthFromEnvWithoutSecurityToken(t *testing.T) {
 
 	auth, _ := NewAuthFromEnv()
 
-	if auth.GetAccessKey() != "asdf" {
+	if swallowErr(auth.GetAccessKey()) != "asdf" {
 		t.Error("Expected AccessKey to be inferred as \"asdf\"")
 	}
 
-	if auth.GetSecretKey() != "asdf2" {
+	if swallowErr(auth.GetSecretKey()) != "asdf2" {
 		t.Error("Expected SecretKey to be inferred as \"asdf2\"")
 	}
 
-	if auth.GetToken() != "" {
+	if swallowErr(auth.GetToken()) != "" {
 		t.Error("Expected SecurityToken to be an empty string")
 	}
 }
@@ -108,11 +112,11 @@ func TestNewAuthFromEnvWithFallbackVars(t *testing.T) {
 
 	auth, _ := NewAuthFromEnv()
 
-	if auth.GetAccessKey() != "asdf" {
+	if swallowErr(auth.GetAccessKey()) != "asdf" {
 		t.Error("Expected AccessKey to be inferred as \"asdf\"")
 	}
 
-	if auth.GetSecretKey() != "asdf2" {
+	if swallowErr(auth.GetSecretKey()) != "asdf2" {
 		t.Error("Expected SecretKey to be inferred as \"asdf2\"")
 	}
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -36,6 +36,23 @@ func TestGetToken(t *testing.T) {
 	}
 }
 
+func TestNewEmptyAuth(t *testing.T) {
+	auth := NewEmptyAuth()
+
+	if auth.GetAccessKey() != "" {
+		t.Error("expected empty auth#accessKey")
+	}
+	if auth.GetSecretKey() != "" {
+		t.Error("expected empty auth#secretKey")
+	}
+	if auth.GetToken() != "" {
+		t.Error("expected empty auth#token")
+	}
+	if auth.HasExpiration() != false {
+		t.Error("expected no expiration")
+	}
+}
+
 func TestNewAuthFromEnv(t *testing.T) {
 	os.Setenv(AccessEnvKey, "asdf")
 	os.Setenv(SecretEnvKey, "asdf2")

--- a/batchproducer/batchproducer.go
+++ b/batchproducer/batchproducer.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sendgridlabs/go-kinesis"
+	"github.com/JoshKCarroll/go-kinesis"
 )
 
 // MaxKinesisBatchSize is the maximum number of records that Kinesis accepts in a request

--- a/batchproducer/batchproducer_test.go
+++ b/batchproducer/batchproducer_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sendgridlabs/go-kinesis"
+	"github.com/JoshKCarroll/go-kinesis"
 )
 
 var (

--- a/client.go
+++ b/client.go
@@ -34,9 +34,12 @@ func NewClientWithHTTPClient(auth Auth, httpClient *http.Client) *Client {
 
 // Do some request, but sign it before sending
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
-	err := Sign(c.auth, req)
-	if err != nil {
-		return nil, err
+	var err error
+	if c.auth.GetAccessKey() != "" {
+		err = Sign(c.auth, req)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if c.auth.HasExpiration() && time.Now().After(c.auth.GetExpiration()) {

--- a/client.go
+++ b/client.go
@@ -2,7 +2,6 @@ package kinesis
 
 import (
 	"net/http"
-	"time"
 )
 
 const AWSSecurityTokenHeader = "X-Amz-Security-Token"
@@ -34,15 +33,12 @@ func NewClientWithHTTPClient(auth Auth, httpClient *http.Client) *Client {
 
 // Do some request, but sign it before sending
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
-	var err error
-	if c.auth.GetAccessKey() != "" {
-		err = Sign(c.auth, req)
-		if err != nil {
-			return nil, err
-		}
+	err := Sign(c.auth, req)
+	if err != nil {
+		return nil, err
 	}
 
-	if c.auth.HasExpiration() && time.Now().After(c.auth.GetExpiration()) {
+	if c.auth.IsExpired() {
 		if err = c.auth.Renew(); err != nil { // TODO: (see auth.go#Renew) may be slow
 			return nil, err
 		}

--- a/client.go
+++ b/client.go
@@ -44,8 +44,12 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		}
 	}
 
-	if c.auth.GetToken() != "" {
-		req.Header.Add(AWSSecurityTokenHeader, c.auth.GetToken())
+	token, err := c.auth.GetToken()
+	if err != nil {
+		return nil, err
+	}
+	if token != "" {
+		req.Header.Add(AWSSecurityTokenHeader, token)
 	}
 
 	return c.client.Do(req)

--- a/examples/example.go
+++ b/examples/example.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	// kinesis "github.com/sendgridlabs/go-kinesis"
-	kinesis "github.com/sendgridlabs/go-kinesis"
+	kinesis "github.com/JoshKCarroll/go-kinesis"
 )
 
 func getRecords(ksis kinesis.KinesisClient, streamName, ShardId string) {

--- a/kinesis-cli/kinesis-cli.go
+++ b/kinesis-cli/kinesis-cli.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	// "github.com/sendgridlabs/go-kinesis"
-	"github.com/sendgridlabs/go-kinesis"
+	"github.com/JoshKCarroll/go-kinesis"
 )
 
 const HELP = `Usage: ./kinesis-cli <command> [<arg>, ...]


### PR DESCRIPTION
Eventually can strip out the old Auth and just use the SDK. Meanwhile, this change allows us to use Kinesis in spaces that the old Auth didn't support, such as Lambda.