### PR TITLE
Add error chan, switch to zap.Logger in batch producer

### DIFF
--- a/batchproducer/event.go
+++ b/batchproducer/event.go
@@ -1,0 +1,28 @@
+package batchproducer
+
+type Event interface {
+	String() string
+}
+
+var (
+	_ Event = (*Error)(nil)
+	_ error = (*Error)(nil)
+)
+
+type Error struct {
+	str string
+}
+
+func newError(str string) *Error {
+	return &Error{
+		str: str,
+	}
+}
+
+func (e *Error) String() string {
+	return e.str
+}
+
+func (e *Error) Error() string {
+	return e.String()
+}


### PR DESCRIPTION
* Use a `*zap.Logger` instead of `*log.Logger` for better control of log levels and formatting
* Add an `Events()` channel for reporting errors to implementing application
